### PR TITLE
Updated Makefile for newer Linux kernels

### DIFF
--- a/ko/Makefile
+++ b/ko/Makefile
@@ -3,6 +3,6 @@ KDIR	:= /lib/modules/$(shell uname -r)/build
 PWD	:= $(shell pwd)
 
 all:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
 clean:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(PWD) clean


### PR DESCRIPTION
Updated Makefile in the ko/ directory to use M= instead of SUBDIRS=. This allows it to run on newer Linux kernels, where SUBDIRS= is deprecated.